### PR TITLE
Swift バックエンドプロトコル型の定義

### DIFF
--- a/.ai-agent/tasks/20260215-swift-backend-protocol/README.md
+++ b/.ai-agent/tasks/20260215-swift-backend-protocol/README.md
@@ -1,0 +1,40 @@
+# Swift Backend Protocol
+
+## 目的・ゴール
+
+Python STT サーバ (`stt-stdio-server/`) との JSON lines プロトコルに対応する Swift 側の Codable 型を定義する。`BackendCommand`（Swift → Python）と `BackendEvent`（Python → Swift）の型安全なシリアライズ/デシリアライズを提供する。
+
+## 依存タスク
+
+- [x] Python STT サーバ (`stt-stdio-server/`): JSON lines プロトコル定義済み
+
+## 実装方針
+
+### ファイル構成
+
+```
+Sources/VoiceInput/Backend/
+  BackendProtocol.swift   # BackendCommand / BackendEvent の Codable 定義
+Tests/VoiceInputTests/
+  BackendProtocolTests.swift  # エンコード/デコードテスト
+```
+
+### 型定義
+
+- **BackendCommand** (enum, Encodable): start / stop / shutdown
+- **BackendEvent** (enum, Decodable): ready / speechStarted / transcription / speechEnded / error
+
+### JSON マッピング
+
+Python 側の snake_case キーに合わせる（`is_final` → `isFinal`, `speech_started` → `speechStarted` など）。
+
+## 完了条件
+
+- [x] BackendCommand が正しい JSON にエンコードされる
+- [x] BackendEvent が Python 側の JSON を正しくデコードできる
+- [x] ユニットテストが通る（11テスト全合格）
+
+## 作業ログ
+
+- 2026-02-15: タスク作成
+- 2026-02-15: 実装完了、全テスト合格

--- a/Sources/VoiceInput/Backend/BackendProtocol.swift
+++ b/Sources/VoiceInput/Backend/BackendProtocol.swift
@@ -1,0 +1,75 @@
+/// JSON lines protocol types for communication with the Python STT server.
+///
+/// Commands are sent from Swift to Python via stdin.
+/// Events are received from Python via stdout.
+
+import Foundation
+
+// MARK: - Commands (Swift → Python)
+
+enum BackendCommand: Sendable {
+    case start
+    case stop
+    case shutdown
+}
+
+extension BackendCommand: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .start:
+            try container.encode("start", forKey: .type)
+        case .stop:
+            try container.encode("stop", forKey: .type)
+        case .shutdown:
+            try container.encode("shutdown", forKey: .type)
+        }
+    }
+}
+
+// MARK: - Events (Python → Swift)
+
+enum BackendEvent: Sendable, Equatable {
+    case ready
+    case speechStarted
+    case transcription(text: String, isFinal: Bool)
+    case speechEnded
+    case error(message: String)
+}
+
+extension BackendEvent: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case isFinal = "is_final"
+        case message
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "ready":
+            self = .ready
+        case "speech_started":
+            self = .speechStarted
+        case "transcription":
+            let text = try container.decode(String.self, forKey: .text)
+            let isFinal = try container.decode(Bool.self, forKey: .isFinal)
+            self = .transcription(text: text, isFinal: isFinal)
+        case "speech_ended":
+            self = .speechEnded
+        case "error":
+            let message = try container.decode(String.self, forKey: .message)
+            self = .error(message: message)
+        default:
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: [CodingKeys.type], debugDescription: "Unknown event type: \(type)")
+            )
+        }
+    }
+}

--- a/Tests/VoiceInputTests/BackendProtocolTests.swift
+++ b/Tests/VoiceInputTests/BackendProtocolTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import VoiceInput
+
+// MARK: - BackendCommand Encoding
+
+@Suite("BackendCommand encoding")
+struct BackendCommandTests {
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return encoder
+    }()
+
+    @Test func encodeStart() throws {
+        let json = try String(data: encoder.encode(BackendCommand.start), encoding: .utf8)
+        #expect(json == #"{"type":"start"}"#)
+    }
+
+    @Test func encodeStop() throws {
+        let json = try String(data: encoder.encode(BackendCommand.stop), encoding: .utf8)
+        #expect(json == #"{"type":"stop"}"#)
+    }
+
+    @Test func encodeShutdown() throws {
+        let json = try String(data: encoder.encode(BackendCommand.shutdown), encoding: .utf8)
+        #expect(json == #"{"type":"shutdown"}"#)
+    }
+}
+
+// MARK: - BackendEvent Decoding
+
+@Suite("BackendEvent decoding")
+struct BackendEventTests {
+    private let decoder = JSONDecoder()
+
+    @Test func decodeReady() throws {
+        let data = Data(#"{"type":"ready"}"#.utf8)
+        let event = try decoder.decode(BackendEvent.self, from: data)
+        #expect(event == .ready)
+    }
+
+    @Test func decodeSpeechStarted() throws {
+        let data = Data(#"{"type":"speech_started"}"#.utf8)
+        let event = try decoder.decode(BackendEvent.self, from: data)
+        #expect(event == .speechStarted)
+    }
+
+    @Test func decodeTranscription() throws {
+        let data = Data(#"{"type":"transcription","text":"こんにちは","is_final":true}"#.utf8)
+        let event = try decoder.decode(BackendEvent.self, from: data)
+        #expect(event == .transcription(text: "こんにちは", isFinal: true))
+    }
+
+    @Test func decodeTranscriptionInterim() throws {
+        let data = Data(#"{"type":"transcription","text":"こん","is_final":false}"#.utf8)
+        let event = try decoder.decode(BackendEvent.self, from: data)
+        #expect(event == .transcription(text: "こん", isFinal: false))
+    }
+
+    @Test func decodeSpeechEnded() throws {
+        let data = Data(#"{"type":"speech_ended"}"#.utf8)
+        let event = try decoder.decode(BackendEvent.self, from: data)
+        #expect(event == .speechEnded)
+    }
+
+    @Test func decodeError() throws {
+        let data = Data(#"{"type":"error","message":"mic not found"}"#.utf8)
+        let event = try decoder.decode(BackendEvent.self, from: data)
+        #expect(event == .error(message: "mic not found"))
+    }
+
+    @Test func decodeUnknownTypeThrows() throws {
+        let data = Data(#"{"type":"unknown"}"#.utf8)
+        #expect(throws: DecodingError.self) {
+            try decoder.decode(BackendEvent.self, from: data)
+        }
+    }
+}


### PR DESCRIPTION
## 目的

Python STT サーバ (`stt-stdio-server/`) の JSON lines プロトコルに対応する Swift 側の Codable 型を定義する。Phase 1 の Swift ↔ Python 連携の基盤となる型定義。

## 変更概要

- `BackendCommand` (enum, Encodable): Swift → Python コマンド (`start` / `stop` / `shutdown`)
- `BackendEvent` (enum, Decodable): Python → Swift イベント (`ready` / `speech_started` / `transcription` / `speech_ended` / `error`)
- Python 側の snake_case JSON キーに対応（`is_final` → `isFinal`, `speech_started` → `.speechStarted` など）
- エンコード/デコードのユニットテスト 10件追加（全11テスト合格）

## 新規ファイル

| ファイル | 内容 |
|---------|------|
| `Sources/VoiceInput/Backend/BackendProtocol.swift` | プロトコル型定義 |
| `Tests/VoiceInputTests/BackendProtocolTests.swift` | ユニットテスト |
| `.ai-agent/tasks/20260215-swift-backend-protocol/README.md` | タスク管理 |