### PR TITLE
devenv 環境でのバックエンド起動失敗を修正

### DIFF
--- a/Tests/VoiceInputTests/BackendManagerTests.swift
+++ b/Tests/VoiceInputTests/BackendManagerTests.swift
@@ -35,7 +35,8 @@ private struct MockCommandResolver: BackendCommandResolver {
     func resolve() throws -> BackendCommand_Launch {
         BackendCommand_Launch(
             executableURL: pythonURL(),
-            arguments: pythonArguments()
+            arguments: pythonArguments(),
+            environment: nil
         )
     }
 }

--- a/Tests/VoiceInputTests/BackendManagerTests.swift
+++ b/Tests/VoiceInputTests/BackendManagerTests.swift
@@ -36,7 +36,8 @@ private struct MockCommandResolver: BackendCommandResolver {
         BackendCommand_Launch(
             executableURL: pythonURL(),
             arguments: pythonArguments(),
-            environment: nil
+            environment: nil,
+            currentDirectoryURL: nil
         )
     }
 }


### PR DESCRIPTION
## 目的

devenv 環境でアプリを起動すると、Python バックエンドが `ModuleNotFoundError` で即座にクラッシュし、タイムアウトエラーになる問題を修正する。

## 背景

2つの問題が重なっていた：

1. **`UV_PROJECT_ENVIRONMENT` の継承**: `devenv.nix` の `languages.python.uv.enable` が設定する `UV_PROJECT_ENVIRONMENT` がサブプロセスに継承され、`uv run --project` が devenv の venv を使用してしまう
2. **virtual project の CWD 依存**: `pyproject.toml` に `[build-system]` がない virtual project では、`uv run` が CWD をもとにソースを `sys.path` に追加する。`--project` で別ディレクトリから起動すると、ソースが見つからず `ModuleNotFoundError` になる

## 変更概要

### バックエンド起動の修正
- `DefaultBackendCommandResolver`: サブプロセスの環境変数から `UV_PROJECT_ENVIRONMENT` を除外
- `DefaultBackendCommandResolver`: サブプロセスの CWD を `stt-stdio-server/` に設定し、virtual project のモジュール解決を修正
- `BackendCommand_Launch`: `environment` / `currentDirectoryURL` フィールドを追加

### エラーメッセージ・ログの改善
- `BackendManagerError` / `ExecutableNotFoundError`: `LocalizedError` 準拠を追加し、日本語でわかりやすいエラーメッセージを表示
- `BackendManager.launch()`: 起動コマンドと失敗理由の詳細ログを追加
- ログの privacy を `.public` に変更し、Console.app でデバッグ時に値が確認できるように